### PR TITLE
feat: add interactive sample viewing for confusion matrix quadrants

### DIFF
--- a/evalkit/metrics/classification.py
+++ b/evalkit/metrics/classification.py
@@ -94,6 +94,13 @@ def calculate_classification_metrics(
         metrics["false_positives"] = int(fp)
         metrics["false_negatives"] = int(fn)
         metrics["true_positives"] = int(tp)
+
+        # Store row indices for each quadrant to enable sample inspection
+        neg_label, pos_label = labels[0], labels[1]
+        metrics["tp_indices"] = list(np.where((y_true == pos_label) & (y_pred == pos_label))[0])
+        metrics["tn_indices"] = list(np.where((y_true == neg_label) & (y_pred == neg_label))[0])
+        metrics["fp_indices"] = list(np.where((y_true == neg_label) & (y_pred == pos_label))[0])
+        metrics["fn_indices"] = list(np.where((y_true == pos_label) & (y_pred == neg_label))[0])
     else:
         metrics["is_binary"] = False
 

--- a/evalkit/tui/app.py
+++ b/evalkit/tui/app.py
@@ -18,6 +18,7 @@ from evalkit.tui.widgets import (
     ExportDialog,
     HelpScreen,
     ErrorDialog,
+    SamplesModal,
 )
 from evalkit.tui.layouts import DashboardLayout
 from evalkit.formatters.exporters import export_results
@@ -33,6 +34,7 @@ class EvalKitApp(App):
         ("h", "help", "Help"),
         ("?", "help", "Help"),
         ("e", "export", "Export"),
+        ("s", "view_samples", "View Samples"),
     ]
 
     def __init__(
@@ -146,6 +148,37 @@ class EvalKitApp(App):
 
         # Use call_after to ensure all widgets are fully mounted
         self.call_after_refresh(show_initial_formula)
+
+    def action_view_samples(self) -> None:
+        """Open samples modal for the currently selected confusion matrix quadrant."""
+        try:
+            formula_panel = self.query_one(MetricFormulaPanel)
+        except Exception:
+            return
+
+        quadrant = formula_panel.current_cm_quadrant
+        if not quadrant:
+            return
+
+        indices_key = f"{quadrant}_indices"
+        indices = self.results.metrics.get(indices_key, [])
+
+        category_names = {
+            "tp": "True Positives",
+            "tn": "True Negatives",
+            "fp": "False Positives",
+            "fn": "False Negatives",
+        }
+        category = category_names[quadrant]
+
+        self.push_screen(
+            SamplesModal(
+                category=category,
+                indices=indices,
+                y_true=self.results.gold,
+                y_pred=self.results.predicted,
+            )
+        )
 
     def on_metrics_table_metric_selected(self, message: MetricsTable.MetricSelected) -> None:
         """

--- a/evalkit/tui/widgets/__init__.py
+++ b/evalkit/tui/widgets/__init__.py
@@ -10,6 +10,7 @@ from evalkit.tui.widgets.metric_formula_panel import MetricFormulaPanel
 from evalkit.tui.widgets.export_dialog import ExportDialog
 from evalkit.tui.widgets.help_screen import HelpScreen
 from evalkit.tui.widgets.error_dialog import ErrorDialog
+from evalkit.tui.widgets.samples_modal import SamplesModal
 
 __all__ = [
     "Header",
@@ -23,4 +24,5 @@ __all__ = [
     "ExportDialog",
     "HelpScreen",
     "ErrorDialog",
+    "SamplesModal",
 ]

--- a/evalkit/tui/widgets/help_screen.py
+++ b/evalkit/tui/widgets/help_screen.py
@@ -54,6 +54,7 @@ class HelpScreen(ModalScreen):
             table.add_row("q / Ctrl+C", "Quit application")
             table.add_row("h / ?", "Show this help")
             table.add_row("e", "Export results")
+            table.add_row("s", "View samples (TP/TN/FP/FN)")
             table.add_row("Tab", "Focus next panel")
             table.add_row("Shift+Tab", "Focus previous panel")
             table.add_row("↑ ↓ ← →", "Navigate/scroll")

--- a/evalkit/tui/widgets/metric_formula_panel.py
+++ b/evalkit/tui/widgets/metric_formula_panel.py
@@ -29,6 +29,7 @@ class MetricFormulaPanel(Container):
         super().__init__()
         self.results = results
         self.selected_metric = None
+        self.current_cm_quadrant: str | None = None  # "tp", "tn", "fp", or "fn"
 
     def on_mount(self) -> None:
         """Set border title after mounting."""
@@ -53,6 +54,15 @@ class MetricFormulaPanel(Container):
         """
         self.selected_metric = metric_name
         self.border_title = f"[bold]{metric_name}[/bold]"
+
+        # Track which CM quadrant is currently displayed (for sample viewing)
+        _cm_quadrants = {
+            "True Positives": "tp",
+            "True Negatives": "tn",
+            "False Positives": "fp",
+            "False Negatives": "fn",
+        }
+        self.current_cm_quadrant = _cm_quadrants.get(metric_name)
 
         # Get formula and calculation
         formula_text = self._get_formula_text(metric_name)
@@ -560,6 +570,24 @@ class MetricFormulaPanel(Container):
 
         total = tp + tn + fp + fn
 
+        # Show hint to view samples if indices are available
+        quadrant_counts = {
+            "True Positives": tp,
+            "True Negatives": tn,
+            "False Positives": fp,
+            "False Negatives": fn,
+        }
+        count = quadrant_counts[highlight_metric]
+        has_indices = "tp_indices" in self.results.metrics
+        if has_indices:
+            sample_word = "sample" if count == 1 else "samples"
+            samples_hint = (
+                f"\n[dim]Press [cyan bold]s[/cyan bold] to view "
+                f"{count} {sample_word} in this category[/dim]"
+            )
+        else:
+            samples_hint = ""
+
         return (
             f"[cyan bold]Confusion Matrix:[/cyan bold]\n\n"
             f"                 Predicted\n"
@@ -575,7 +603,8 @@ class MetricFormulaPanel(Container):
             f"{tp_style}True Positives (TP)[/]:  {tp} ({tp/total*100:.1f}%)\n"
             f"{tn_style}True Negatives (TN)[/]:  {tn} ({tn/total*100:.1f}%)\n"
             f"{fp_style}False Positives (FP)[/]: {fp} ({fp/total*100:.1f}%)\n"
-            f"{fn_style}False Negatives (FN)[/]: {fn} ({fn/total*100:.1f}%)\n"
+            f"{fn_style}False Negatives (FN)[/]: {fn} ({fn/total*100:.1f}%)"
+            f"{samples_hint}\n"
         )
 
     DEFAULT_CSS = """

--- a/evalkit/tui/widgets/samples_modal.py
+++ b/evalkit/tui/widgets/samples_modal.py
@@ -1,0 +1,133 @@
+"""Samples modal widget for viewing confusion matrix quadrant examples."""
+
+import numpy as np
+from textual.app import ComposeResult
+from textual.containers import Vertical
+from textual.screen import ModalScreen
+from textual.widgets import Button, DataTable, Static
+
+
+MAX_SAMPLES = 50
+
+
+class SamplesModal(ModalScreen):
+    """
+    Modal screen displaying sample predictions for a confusion matrix quadrant.
+
+    Shows a scrollable table of examples (row index, true label, predicted label)
+    from a selected TP/TN/FP/FN category.
+    """
+
+    BINDINGS = [
+        ("escape", "app.pop_screen", "Close"),
+        ("q", "app.pop_screen", "Close"),
+    ]
+
+    DEFAULT_CSS = """
+    SamplesModal {
+        align: center middle;
+    }
+
+    SamplesModal > Vertical {
+        background: $surface;
+        border: thick $primary;
+        width: 70;
+        height: 30;
+        padding: 1 2;
+    }
+
+    SamplesModal #modal-title {
+        text-align: center;
+        margin-bottom: 1;
+    }
+
+    SamplesModal #no-samples {
+        text-align: center;
+        color: $text-muted;
+        margin: 2;
+    }
+
+    SamplesModal DataTable {
+        height: 1fr;
+        margin-bottom: 1;
+    }
+
+    SamplesModal Button {
+        width: 100%;
+        margin-top: 1;
+    }
+    """
+
+    def __init__(
+        self,
+        category: str,
+        indices: list[int],
+        y_true: np.ndarray,
+        y_pred: np.ndarray,
+    ) -> None:
+        """
+        Initialize samples modal.
+
+        Args:
+            category: Name of the confusion matrix category (e.g. "True Positives")
+            indices: Row indices of samples in this category
+            y_true: Ground truth labels array
+            y_pred: Predicted labels array
+        """
+        super().__init__()
+        self.category = category
+        self.all_indices = indices
+        self.display_indices = indices[:MAX_SAMPLES]
+        self.y_true = y_true
+        self.y_pred = y_pred
+
+    def compose(self) -> ComposeResult:
+        """
+        Compose samples modal content.
+
+        Returns:
+            Generator yielding modal widgets
+        """
+        total = len(self.all_indices)
+        showing = len(self.display_indices)
+
+        title = f"[cyan bold]{self.category}[/cyan bold]"
+        if total == 0:
+            subtitle = "[dim]0 samples[/dim]"
+        elif total > MAX_SAMPLES:
+            subtitle = f"[dim]Showing first {showing} of {total} samples[/dim]"
+        else:
+            subtitle = f"[dim]{total} sample{'s' if total != 1 else ''}[/dim]"
+
+        with Vertical():
+            yield Static(f"{title}\n{subtitle}", id="modal-title")
+
+            if not self.display_indices:
+                yield Static(
+                    "[dim]No samples found in this category.[/dim]",
+                    id="no-samples",
+                )
+            else:
+                yield DataTable(id="samples-table")
+
+            yield Button("Close [dim](Esc / q)[/dim]", variant="primary", id="close-btn")
+
+    def on_mount(self) -> None:
+        """Populate the data table after mounting."""
+        if not self.display_indices:
+            return
+
+        table = self.query_one("#samples-table", DataTable)
+        table.add_columns("Row", "True Label", "Predicted Label")
+        for idx in self.display_indices:
+            table.add_row(str(idx), str(self.y_true[idx]), str(self.y_pred[idx]))
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        """
+        Handle button press events.
+
+        Args:
+            event: Button pressed event
+        """
+        if event.button.id == "close-btn":
+            self.dismiss()

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -72,6 +72,55 @@ class TestClassificationMetrics:
         assert metrics["false_positives"] == 1
         assert metrics["false_negatives"] == 2
 
+    def test_binary_quadrant_indices_stored(self):
+        """Test that TP/TN/FP/FN row indices are stored for binary classification."""
+        # labels sorted: [0, 1] -> neg=0, pos=1
+        # Indices: 0→TN, 1→TP, 2→FP, 3→FN, 4→TN, 5→TP
+        y_true = np.array([0, 1, 0, 1, 0, 1])
+        y_pred = np.array([0, 1, 1, 0, 0, 1])
+
+        metrics = calculate_classification_metrics(y_true, y_pred)
+
+        assert "tp_indices" in metrics
+        assert "tn_indices" in metrics
+        assert "fp_indices" in metrics
+        assert "fn_indices" in metrics
+
+        assert sorted(metrics["tp_indices"]) == [1, 5]
+        assert sorted(metrics["tn_indices"]) == [0, 4]
+        assert sorted(metrics["fp_indices"]) == [2]
+        assert sorted(metrics["fn_indices"]) == [3]
+
+        # Counts should match TP/TN/FP/FN metric values
+        assert len(metrics["tp_indices"]) == metrics["true_positives"]
+        assert len(metrics["tn_indices"]) == metrics["true_negatives"]
+        assert len(metrics["fp_indices"]) == metrics["false_positives"]
+        assert len(metrics["fn_indices"]) == metrics["false_negatives"]
+
+    def test_multiclass_no_quadrant_indices(self):
+        """Test that quadrant indices are not stored for multiclass classification."""
+        y_true = np.array(["cat", "dog", "bird", "cat"])
+        y_pred = np.array(["cat", "dog", "cat", "cat"])
+
+        metrics = calculate_classification_metrics(y_true, y_pred)
+
+        assert "tp_indices" not in metrics
+        assert "tn_indices" not in metrics
+        assert "fp_indices" not in metrics
+        assert "fn_indices" not in metrics
+
+    def test_binary_quadrant_indices_empty_category(self):
+        """Test quadrant indices when a category has zero samples (perfect predictions)."""
+        y_true = np.array([0, 1, 0, 1])
+        y_pred = np.array([0, 1, 0, 1])
+
+        metrics = calculate_classification_metrics(y_true, y_pred)
+
+        assert metrics["fp_indices"] == []
+        assert metrics["fn_indices"] == []
+        assert len(metrics["tp_indices"]) == 2
+        assert len(metrics["tn_indices"]) == 2
+
 
 class TestRegressionMetrics:
     """Tests for regression metrics."""

--- a/tests/tui/test_widgets.py
+++ b/tests/tui/test_widgets.py
@@ -9,6 +9,7 @@ from evalkit.tui.widgets.confusion_matrix import ConfusionMatrixWidget
 from evalkit.tui.widgets.graph_panel import ScatterPlot, BarChart
 from evalkit.tui.widgets.error_dialog import ErrorDialog
 from evalkit.tui.widgets.help_screen import HelpScreen
+from evalkit.tui.widgets.samples_modal import SamplesModal, MAX_SAMPLES
 from evalkit.types import EvaluationResults, EvaluationMode
 from textual.widgets import Footer as TextualFooter
 from textual.app import App
@@ -253,4 +254,109 @@ async def test_help_screen():
     app = TestApp()
     async with app.run_test():
         # Help screen should be pushed
+        assert len(app.screen_stack) > 0
+
+
+def test_samples_modal_instantiation():
+    """Test SamplesModal can be instantiated with basic parameters."""
+    y_true = np.array([0, 1, 0, 1, 0, 1])
+    y_pred = np.array([0, 1, 1, 0, 0, 1])
+    indices = [1, 5]
+
+    modal = SamplesModal(
+        category="True Positives",
+        indices=indices,
+        y_true=y_true,
+        y_pred=y_pred,
+    )
+
+    assert modal.category == "True Positives"
+    assert modal.all_indices == indices
+    assert modal.display_indices == indices
+    assert len(modal.y_true) == len(y_true)
+    assert len(modal.y_pred) == len(y_pred)
+
+
+def test_samples_modal_empty_indices():
+    """Test SamplesModal with zero samples (empty category)."""
+    y_true = np.array([0, 1, 0, 1])
+    y_pred = np.array([0, 1, 0, 1])
+
+    modal = SamplesModal(
+        category="False Positives",
+        indices=[],
+        y_true=y_true,
+        y_pred=y_pred,
+    )
+
+    assert modal.all_indices == []
+    assert modal.display_indices == []
+    assert hasattr(modal, 'compose')
+    assert callable(modal.compose)
+
+
+def test_samples_modal_truncates_to_max_samples():
+    """Test SamplesModal truncates to MAX_SAMPLES for large index lists."""
+    y_true = np.zeros(MAX_SAMPLES + 10, dtype=int)
+    y_pred = np.zeros(MAX_SAMPLES + 10, dtype=int)
+    indices = list(range(MAX_SAMPLES + 10))
+
+    modal = SamplesModal(
+        category="True Negatives",
+        indices=indices,
+        y_true=y_true,
+        y_pred=y_pred,
+    )
+
+    assert len(modal.all_indices) == MAX_SAMPLES + 10
+    assert len(modal.display_indices) == MAX_SAMPLES
+
+
+@pytest.mark.asyncio
+async def test_samples_modal_renders_in_app():
+    """Test SamplesModal can be pushed onto screen stack in an app context."""
+    y_true = np.array([0, 1, 0, 1, 0, 1])
+    y_pred = np.array([0, 1, 1, 0, 0, 1])
+
+    class TestApp(App):
+        def __init__(self):
+            super().__init__()
+
+        def on_mount(self) -> None:
+            self.push_screen(
+                SamplesModal(
+                    category="True Positives",
+                    indices=[1, 5],
+                    y_true=y_true,
+                    y_pred=y_pred,
+                )
+            )
+
+    app = TestApp()
+    async with app.run_test():
+        assert len(app.screen_stack) > 0
+
+
+@pytest.mark.asyncio
+async def test_samples_modal_empty_renders_in_app():
+    """Test SamplesModal with empty indices renders without errors."""
+    y_true = np.array([0, 1, 0, 1])
+    y_pred = np.array([0, 1, 0, 1])
+
+    class TestApp(App):
+        def __init__(self):
+            super().__init__()
+
+        def on_mount(self) -> None:
+            self.push_screen(
+                SamplesModal(
+                    category="False Positives",
+                    indices=[],
+                    y_true=y_true,
+                    y_pred=y_pred,
+                )
+            )
+
+    app = TestApp()
+    async with app.run_test():
         assert len(app.screen_stack) > 0


### PR DESCRIPTION
When a TP/TN/FP/FN metric is selected in the formula panel, users can press `s` to open a modal showing the actual predictions in that category.

## Changes

- Store row indices per quadrant in `calculate_classification_metrics()` for binary classification
- New `SamplesModal` widget with DataTable (row, true label, predicted label), capped at 50 rows
- "Press s to view N samples" hint in confusion matrix display
- `s` key binding and `action_view_samples()` in `EvalKitApp`
- Help screen updated with `s` shortcut
- Tests for index tracking and SamplesModal widget

Closes #10

Generated with [Claude Code](https://claude.ai/code)